### PR TITLE
Make "Tools" section of README render nicer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,11 @@ If you intend to use, for example PostgreSQL instead of SQLite (which is default
     pip install psycopg2
 
 #### Tools
-If you don't have any of these front-end tools installed do so
-  `npm install -g grunt-cli`
-  `npm install -g bower`
-  `gem install compass`
-  `npm install -g yo`
-  `npm install -g generator-angular`
-  `npm install -g grunt-karma`
+You will need several front end tools, which you can install from npm and gem:
+```shell
+$ npm install -g grunt-cli bower yo generator-angular grunt-karma
+$ gem install compass
+```
 
 #### Project
 Then go ahead and pull down the repo and run `npm install` and `bower install` in the project directory.


### PR DESCRIPTION
I think this reads a little better in the rendered view. If you don't like having all the npm deps on one line, I would still recommend putting them in a code block instead of inlines, so they don't all end up on one line in the rendered view.
